### PR TITLE
feat: Auto-wrap native NEAR for Burrow supply

### DIFF
--- a/src/components/defi/BurrowSupply.tsx
+++ b/src/components/defi/BurrowSupply.tsx
@@ -42,8 +42,18 @@ const BurrowSupply = () => {
   );
   const depositMutation = useSupplyToBurrow();
 
+  // Helper to get display symbol for tokens in Burrow context
+  const getTokenDisplaySymbol = (token: NonNullable<typeof tokensQuery.data>[0]) => {
+    if (token.account_id === "near") {
+      return "NEAR (native)";
+    }
+    if (token.account_id === "wrap.near") {
+      return "wNEAR (wrapped)";
+    }
+    return token.symbol;
+  };
+
   const onSubmit = (values: z.infer<typeof burrowSupplyFormSchema>) => {
-    console.log(values);
     depositMutation.mutate(values);
   };
 
@@ -63,97 +73,114 @@ const BurrowSupply = () => {
           label="Sender"
         />
 
-        <div className="flex flex-grow flex-row">
-          <FormField
-            control={form.control}
-            name="token"
-            render={({ field }) => (
-              <FormItem className="flex flex-col">
-                <FormLabel>Token</FormLabel>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <FormControl>
-                      <Button
-                        variant="outline"
-                        role="combobox"
-                        className={cn(
-                          "br w-[100px] max-w-[100px] justify-between rounded-r-none border-r-0",
-                          !field.value && "text-muted-foreground",
-                        )}
-                        disabled={tokensQuery.isLoading}
-                      >
-                        {tokensQuery.isLoading && "Loading..."}
-                        {!tokensQuery.isLoading &&
-                          (field.value
-                            ? tokensQuery.data?.find(
-                                (token) => token.account_id === field.value,
-                              )?.symbol
-                            : "Select token")}
-                        <ChevronUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                      </Button>
-                    </FormControl>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-[350px] p-0">
-                    <Command>
-                      <CommandInput placeholder="Search token..." />
-                      <CommandEmpty>No token found.</CommandEmpty>
-                      <CommandGroup>
-                        {tokensQuery.isLoading && "Loading..."}
-                        {!tokensQuery.isLoading &&
-                          tokensQuery.data?.map((token) => (
-                            <CommandItem
-                              value={token.account_id}
-                              key={token.account_id}
-                              onSelect={() => {
-                                form.setValue("token", token.account_id);
-                              }}
-                            >
-                              <CheckIcon
-                                className={cn(
-                                  "mr-2 h-4 w-4",
-                                  token.account_id === field.value
-                                    ? "opacity-100"
-                                    : "opacity-0",
-                                )}
-                              />
-                              {`${token.symbol} (${getFormattedAmount(token)})`}
-                            </CommandItem>
-                          ))}
-                      </CommandGroup>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
-                <FormMessage />
-              </FormItem>
+        <div className="space-y-2">
+          <div className="flex flex-row">
+            <FormField
+              control={form.control}
+              name="token"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>Token</FormLabel>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <FormControl>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          className={cn(
+                            "w-[160px] justify-between rounded-r-none border-r-0",
+                            !field.value && "text-muted-foreground",
+                          )}
+                          disabled={tokensQuery.isLoading}
+                        >
+                          {tokensQuery.isLoading && "Loading..."}
+                          {!tokensQuery.isLoading &&
+                            (field.value
+                              ? (() => {
+                                  const token = tokensQuery.data?.find(
+                                    (t) => t.account_id === field.value,
+                                  );
+                                  return token ? getTokenDisplaySymbol(token) : "Select token";
+                                })()
+                              : "Select token")}
+                          <ChevronUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      </FormControl>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[350px] p-0">
+                      <Command>
+                        <CommandInput placeholder="Search token..." />
+                        <CommandEmpty>No token found.</CommandEmpty>
+                        <CommandGroup>
+                          {tokensQuery.isLoading && "Loading..."}
+                          {!tokensQuery.isLoading &&
+                            tokensQuery.data?.map((token) => (
+                              <CommandItem
+                                value={token.account_id}
+                                key={token.account_id}
+                                onSelect={() => {
+                                  form.setValue("token", token.account_id);
+                                }}
+                              >
+                                <CheckIcon
+                                  className={cn(
+                                    "mr-2 h-4 w-4",
+                                    token.account_id === field.value
+                                      ? "opacity-100"
+                                      : "opacity-0",
+                                  )}
+                                />
+                                {`${getTokenDisplaySymbol(token)} (${getFormattedAmount(token)})`}
+                              </CommandItem>
+                            ))}
+                        </CommandGroup>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tokenAmount"
+              render={({ field }) => (
+                <FormItem className="flex flex-grow flex-col">
+                  <FormLabel>Amount</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="0"
+                      type="number"
+                      className="flex rounded-l-none border"
+                      value={field.value}
+                      onChange={(e) => {
+                        try {
+                          const value = parseFloat(e.target.value || "");
+                          form.setValue("tokenAmount", value);
+                        } catch {
+                          form.setValue("tokenAmount", 0);
+                        }
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {form.watch("token") === "near" ? (
+              <span className="text-amber-600 dark:text-amber-400">
+                Native NEAR will be automatically wrapped to wNEAR, then supplied to Burrow.
+              </span>
+            ) : form.watch("token") === "wrap.near" ? (
+              <span className="text-green-600 dark:text-green-400">
+                This is the wrapped NEAR token required by Burrow.
+              </span>
+            ) : (
+              "Select a token to supply. Native NEAR will be automatically wrapped."
             )}
-          />
-          <FormField
-            control={form.control}
-            name="tokenAmount"
-            render={({ field }) => (
-              <FormItem className="flex flex-grow flex-col">
-                <FormLabel>Amount</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="0"
-                    type="number"
-                    className="flex rounded-l-none border "
-                    value={field.value}
-                    onChange={(e) => {
-                      try {
-                        const value = parseFloat(e.target.value || "");
-                        form.setValue("tokenAmount", value);
-                      } catch {
-                        form.setValue("tokenAmount", 0);
-                      }
-                    }}
-                  />
-                </FormControl>
-                {/* <FormDescription>Balance: {0}</FormDescription> */}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          </p>
         </div>
 
         <Button type="submit">Create supply request</Button>

--- a/src/hooks/defi.ts
+++ b/src/hooks/defi.ts
@@ -667,6 +667,37 @@ interface Config {
   volatility_ratio: number;
 }
 
+export const useWrapNear = () => {
+  const wsStore = useWalletTerminator();
+
+  return useMutation({
+    mutationFn: async (params: { fundingAccId: string; amount: string }) => {
+      const wrapNearAccountId = "wrap.near";
+      const yoctoAmount = parseNearAmount(params.amount);
+
+      const wrapRequest = transactions.functionCall(
+        "add_request",
+        addMultisigRequestAction(wrapNearAccountId, [
+          functionCallAction(
+            "near_deposit",
+            {},
+            yoctoAmount,
+            (50 * TGas).toString(),
+          ),
+        ]),
+        new BN(100 * TGas),
+        new BN("0"),
+      );
+
+      await wsStore.signAndSendTransaction({
+        senderId: params.fundingAccId,
+        receiverId: params.fundingAccId,
+        actions: [wrapRequest],
+      });
+    },
+  });
+};
+
 export const burrowSupplyFormSchema = z.object({
   token: z.string(),
   tokenAmount: z.number(),
@@ -676,9 +707,13 @@ export const burrowSupplyFormSchema = z.object({
 export const useSupplyToBurrow = () => {
   const wsStore = useWalletTerminator();
   const { getProvider } = usePersistingStore();
+  const wrapNearMutation = useWrapNear();
 
   return useMutation({
     mutationFn: async (params: z.infer<typeof burrowSupplyFormSchema>) => {
+      // Check wallet connection early to avoid multiple error popups
+      await wsStore.canSignForAccount(params.funding);
+
       const burrowAccountId = "contract.main.burrow.near";
 
       const storageDepositRequest = transactions.functionCall(
@@ -698,38 +733,67 @@ export const useSupplyToBurrow = () => {
         new BN("0"),
       );
 
+      const provider = getProvider();
+      // Burrow uses wrap.near for native NEAR
+      const burrowTokenId = params.token === "near" ? "wrap.near" : params.token;
+
       const config = await viewCall<BurrowAssetConfig>(
         burrowAccountId,
         "get_asset",
-        { token_id: params.token },
-        getProvider()
+        { token_id: burrowTokenId },
+        provider,
       );
 
-      const ftMetadata = await viewCall<FungibleTokenMetadata>(
-        params.token,
-        "ft_metadata",
-        {},
-        getProvider()
-      );
+      let ftMetadata: FungibleTokenMetadata;
+
+      // Handle native NEAR specially - it doesn't have ft_metadata
+      if (params.token === "near") {
+        ftMetadata = {
+          spec: "ft-1.0.0",
+          name: "NEAR",
+          symbol: "NEAR",
+          icon: null,
+          reference: null,
+          reference_hash: null,
+          decimals: 24,
+        };
+      } else {
+        ftMetadata = await viewCall<FungibleTokenMetadata>(
+          params.token,
+          "ft_metadata",
+          {},
+          getProvider(),
+        );
+      }
 
       const indivisibleAmount = convertToIndivisibleFormat(
         params.tokenAmount.toString(),
         ftMetadata.decimals,
       );
 
+      // For native NEAR, use wrap.near for the transfer
+      const transferTokenId = params.token === "near" ? "wrap.near" : params.token;
+
+      // If native NEAR is selected, wrap it first before transferring to Burrow
+      if (params.token === "near") {
+        await wrapNearMutation.mutateAsync({
+          fundingAccId: params.funding,
+          amount: params.tokenAmount.toString(),
+        });
+      }
+
       const ftTransferCall = transactions.functionCall(
         "add_request",
-        addMultisigRequestAction(params.token, [
+        addMultisigRequestAction(transferTokenId, [
           functionCallAction(
             "ft_transfer_call",
             {
               receiver_id: burrowAccountId,
               amount: indivisibleAmount.toString(),
               msg: config.config.can_use_as_collateral
-                ? `{\"Execute\":{\"actions\":[{\"IncreaseCollateral\":{\"token_id\":\"${params.token
-                }\",\"max_amount\":\"${indivisibleAmount.toString()}${"0".repeat(
-                  config.config.extra_decimals,
-                )}\"}}]}}`
+                ? `{\"Execute\":{\"actions\":[{\"IncreaseCollateral\":{\"token_id\":\"${burrowTokenId}\",\"max_amount\":\"${indivisibleAmount.toString()}${"0".repeat(
+                    config.config.extra_decimals,
+                  )}\"}}]}}`
                 : "",
             },
             "1",

--- a/src/store/slices/wallet-selector.ts
+++ b/src/store/slices/wallet-selector.ts
@@ -314,7 +314,6 @@ export const createWalletTerminator: StateCreator<
     return tx;
   },
   signAndSendTransaction: async (params) => {
-    console.log("signAndSendTransaction", params);
     try {
       // find a pk that can be used to sign for the senderId
       await get().canSignForAccount(params.senderId);
@@ -325,7 +324,6 @@ export const createWalletTerminator: StateCreator<
           publicKeyForTxn = pk;
         }
       }
-      console.log(publicKeyForTxn);
 
       const tx = await get().createTx(
         publicKeyForTxn,
@@ -334,7 +332,6 @@ export const createWalletTerminator: StateCreator<
         params.action,
         params.actions,
       );
-      console.log("signAndSendTransaction", { tx });
 
       const source = get().sources[publicKeyForTxn];
       if (source.type === "ledger") {


### PR DESCRIPTION
## Summary

- Add automatic wrapping of native NEAR to wNEAR when users supply to Burrow Finance
- Improve UX by showing clear labels for "NEAR (native)" vs "wNEAR (wrapped)" in token selector
- Add early wallet connection check to prevent multiple error popups when wallet is not connected
- Show contextual helper text explaining the wrapping process

## Changes

### New: `useWrapNear` hook
Wraps native NEAR by calling `near_deposit` on `wrap.near` contract with attached deposit.

### Modified: `useSupplyToBurrow`
- Check wallet connection early to fail fast with single error popup
- Detect when native NEAR is selected and automatically wrap it before transfer
- Use `wrap.near` token ID for Burrow interactions when native NEAR is selected

### Updated: `BurrowSupply` UI
- Show "NEAR (native)" and "wNEAR (wrapped)" labels in token dropdown
- Display contextual helper text explaining wrapping behavior
- Widen token selector button to accommodate longer labels

## Test plan

- [ ] Select native NEAR in Burrow supply form
- [ ] Verify helper text shows wrapping message
- [ ] Submit form and verify wrap transaction appears before supply transaction
- [ ] Test with wNEAR directly to ensure existing flow still works
- [ ] Test with wallet not connected to verify single error popup