### PR TITLE
fix: Attach 1 yoctoNEAR deposit on Burrow withdraw

### DIFF
--- a/src/hooks/defi.ts
+++ b/src/hooks/defi.ts
@@ -896,7 +896,7 @@ export const useWithdrawSupplyFromBurrow = () => {
                   },
                 ],
               },
-              "0",
+              "1",
               (200 * TGas).toString(),
             ),
           ]),


### PR DESCRIPTION
## Summary
- Burrow's `execute_with_pyth` requires exactly 1 yoctoNEAR attached for all calls
- The non-collateral withdrawal path in `useWithdrawSupplyFromBurrow()` was sending `"0"` instead of `"1"`
- This caused "Smart contract panicked: Requires attached deposit of exactly 1 yoctoNEAR" errors since the Burrow contract reopened

## Change
One-line fix in `src/hooks/defi.ts:899` — changed deposit from `"0"` to `"1"`.