### PR TITLE
Add previous multisig hash to vulnerable set

### DIFF
--- a/src/lib/multisig/upgrade.ts
+++ b/src/lib/multisig/upgrade.ts
@@ -8,6 +8,7 @@ import { type MultiSigAction } from "./contract";
 export const VULNERABLE_MULTISIG_HASHES: ReadonlySet<string> = new Set([
   "55E7imniT2uuYrECn17qJAk9fLcwQW4ftNSwmCJL5Di",
   "5WFgvKK2DizfgEcey6xBkn4RdTe9cGNWzGK5VJuUtc8d",
+  "63AVHGvscPnyhXxW6dmC9Vmofx2QWiFKRLb2tojS95Pw",
 ]);
 
 export const NEW_MULTISIG_HASH =


### PR DESCRIPTION
## Summary
- Add `63AVHGvscPnyhXxW6dmC9Vmofx2QWiFKRLb2tojS95Pw` (the previous multisig contract hash) to `VULNERABLE_MULTISIG_HASHES`
- Wallets still running the prior version are now eligible for upgrade to the patched contract

## Test plan
- [ ] Verify wallets with the old hash show as "eligible" in the upgrade UI
- [ ] Confirm wallets with the new patched hash still show as "already-upgraded"