### PR TITLE
Notify open tabs when a new version is deployed

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,12 @@ await import("./src/env.mjs");
 const config = {
   reactStrictMode: true,
   swcMinify: true,
+  generateBuildId: async () => {
+    return process.env.VERCEL_GIT_COMMIT_SHA ?? crypto.randomUUID();
+  },
+  publicRuntimeConfig: {
+    buildId: process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
+  },
   i18n: {
     locales: ["en"],
     defaultLocale: "en",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const config = {
   reactStrictMode: true,
   swcMinify: true,
   generateBuildId: async () => {
-    return process.env.VERCEL_GIT_COMMIT_SHA ?? crypto.randomUUID();
+    return process.env.VERCEL_GIT_COMMIT_SHA ?? "dev";
   },
   publicRuntimeConfig: {
     buildId: process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",

--- a/src/hooks/useNewVersionCheck.ts
+++ b/src/hooks/useNewVersionCheck.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+import { toast } from "react-toastify";
+
+const POLL_INTERVAL_MS = 60_000;
+
+function getClientBuildId(): string {
+  if (typeof window === "undefined") return "unknown";
+  return (
+    (window as unknown as { __NEXT_DATA__?: { buildId?: string } })
+      .__NEXT_DATA__?.buildId ?? "unknown"
+  );
+}
+
+async function fetchServerBuildId(): Promise<string | null> {
+  try {
+    const res = await fetch("/api/version", { cache: "no-store" });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { buildId?: string };
+    return data.buildId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function useNewVersionCheck() {
+  const notifiedRef = useRef(false);
+
+  useEffect(() => {
+    const clientBuildId = getClientBuildId();
+    if (clientBuildId === "unknown" || clientBuildId === "dev") return;
+
+    async function check() {
+      if (notifiedRef.current) return;
+      const serverBuildId = await fetchServerBuildId();
+      if (!serverBuildId || serverBuildId === clientBuildId) return;
+
+      notifiedRef.current = true;
+      toast.info("A new version is available. Click here to refresh.", {
+        autoClose: false,
+        closeOnClick: false,
+        onClick: () => window.location.reload(),
+      });
+    }
+
+    const interval = setInterval(() => void check(), POLL_INTERVAL_MS);
+
+    function onVisibilityChange() {
+      if (document.visibilityState === "visible") void check();
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import "@near-wallet-selector/modal-ui/styles.css";
 import "react-toastify/dist/ReactToastify.css";
 import { WalletHome } from "~/components/Modal/ModalHome";
 import "~/styles/globals.css";
+import { useNewVersionCheck } from "~/hooks/useNewVersionCheck";
 
 config.autoAddCss = false;
 
@@ -38,6 +39,7 @@ const queryClient = new QueryClient({
 });
 
 function MyApp({ Component, pageProps, session }: AppPropsWithLayout) {
+  useNewVersionCheck();
   const { getLayout } = Component;
 
   const pageContent = <Component {...pageProps} />;

--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import getConfig from "next/config";
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const { publicRuntimeConfig } = getConfig() ?? {};
+  const buildId =
+    (publicRuntimeConfig as { buildId?: string })?.buildId ?? "unknown";
+  res.setHeader("Cache-Control", "no-store");
+  res.json({ buildId });
+}


### PR DESCRIPTION
## Summary
- Adds `/api/version` endpoint returning the current build ID (commit SHA on Vercel)
- Adds `useNewVersionCheck` hook that polls every 60s + on tab focus
- Shows a react-toastify notification when a new deployment is detected, prompting refresh
- No new dependencies — uses existing react-toastify

## Why
Users who opened nearvault before the multisig upgrade was deployed are running a stale bundle and don't see the upgrade option. This ensures open tabs detect new deployments within 60 seconds.

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Open the app, then redeploy — open tab should show "new version available" toast within 60s
- [ ] Clicking the toast should reload the page
- [ ] Verify `/api/version` returns `{ "buildId": "<commit-sha>" }` with `Cache-Control: no-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)