### PR TITLE
Fix staged DeFi withdrawals

### DIFF
--- a/src/components/defi/BurrowWithdraw.tsx
+++ b/src/components/defi/BurrowWithdraw.tsx
@@ -6,9 +6,10 @@ import { type z } from "zod";
 import {
   burrowWithdrawFormSchema,
   useGetBurrowSuppliedTokens,
-  useWithdrawAllSupplyFromBurrow,
+  useGetTokenStorageBalance,
   useWithdrawSupplyFromBurrow,
 } from "~/hooks/defi";
+import { type BurrowPositionType } from "~/lib/defi/requests";
 import { useZodForm } from "~/hooks/form";
 import { useTeamsWalletsWithLockups } from "~/hooks/teams";
 import { getFormattedAmount } from "~/lib/transformations";
@@ -43,21 +44,47 @@ const BurrowWithdraw = () => {
     form.watch("funding"),
   );
   const withdrawMutation = useWithdrawSupplyFromBurrow();
-  const withdrawAllMutation = useWithdrawAllSupplyFromBurrow();
-  const currentCollateral =
+  const currentTokenDetails =
     currentToken && burrowCollateralsQuery.data
       ? burrowCollateralsQuery.data.tokens.find(
-        (token) => token.ftMetadata.accountId === currentToken,
-      )
+          (token) => token.ftMetadata.accountId === currentToken,
+        )
       : undefined;
 
-  const [selectedTokenType, setSelectedTokenType] = useState<'collateral' | 'supplied' | null>(null);
+  const [selectedTokenType, setSelectedTokenType] =
+    useState<BurrowPositionType | null>(null);
+
+  const currentHolding =
+    selectedTokenType && currentToken && burrowCollateralsQuery.data
+      ? burrowCollateralsQuery.data.holdings[selectedTokenType].find(
+          (holding) => holding.token_id === currentToken,
+        )
+      : undefined;
+
+  const storageBalanceQuery = useGetTokenStorageBalance(
+    currentToken,
+    form.watch("funding"),
+  );
+
+  const selectedSymbol = currentTokenDetails?.ftMetadata.symbol || "token";
+  const needsStorageRegistration =
+    !!currentToken &&
+    !!form.watch("funding") &&
+    storageBalanceQuery.data === null;
+  const getTokenDetails = (tokenId: string) => {
+    return burrowCollateralsQuery.data?.tokens.find(
+      (token) => token.ftMetadata.accountId === tokenId,
+    );
+  };
 
   const onSubmit = (values: z.infer<typeof burrowWithdrawFormSchema>) => {
-    if (selectedTokenType === 'supplied') {
-      withdrawAllMutation.mutate({ token: values.token, funding: values.funding });
-    } else if (selectedTokenType === 'collateral') {
-      withdrawMutation.mutate(values);
+    if (selectedTokenType) {
+      withdrawMutation.mutate({
+        token: values.token,
+        funding: values.funding,
+        positionType: selectedTokenType,
+        amount: values.tokenAmount,
+      });
     }
   };
 
@@ -96,10 +123,10 @@ const BurrowWithdraw = () => {
                         {!burrowCollateralsQuery.isLoading &&
                           (field.value
                             ? burrowCollateralsQuery.data?.tokens.find(
-                              (token) =>
-                                token.ftMetadata.accountId === field.value,
-                            )?.ftMetadata.symbol
-                            : "Select collateral token")}
+                                (token) =>
+                                  token.ftMetadata.accountId === field.value,
+                              )?.ftMetadata.symbol
+                            : "Select Burrow position")}
                         <ChevronUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                       </Button>
                     </FormControl>
@@ -111,81 +138,89 @@ const BurrowWithdraw = () => {
                       {!burrowCollateralsQuery.isLoading && (
                         <>
                           <CommandGroup heading="Collateral">
-                            {burrowCollateralsQuery.data?.tokens
-                              .filter(token =>
-                                burrowCollateralsQuery.data?.holdings.collateral
-                                  .some(holding => holding.token_id === token.ftMetadata.accountId)
-                              )
-                              .map((token) => (
-                                <CommandItem
-                                  value={`collateral-${token.ftMetadata.accountId}`}
-                                  key={`collateral-${token.ftMetadata.accountId}`}
-                                  onSelect={() => {
-                                    form.setValue(
-                                      "token",
-                                      token.ftMetadata.accountId,
-                                    );
-                                    setSelectedTokenType('collateral');
-                                  }}
-                                >
-                                  <CheckIcon
-                                    className={cn(
-                                      "mr-2 h-4 w-4",
-                                      token.ftMetadata.accountId === field.value
-                                        ? "opacity-100"
-                                        : "opacity-0",
-                                    )}
-                                  />
-                                  {`${token.ftMetadata.symbol} (Collateral: ${getFormattedAmount({
-                                    balance: burrowCollateralsQuery.data?.holdings.collateral
-                                      .find(holding => holding.token_id === token.ftMetadata.accountId)
-                                      ?.balance || "0",
-                                    decimals:
-                                      token.ftMetadata.decimals +
-                                      token.config.config.extra_decimals,
-                                    symbol: token.ftMetadata.symbol,
-                                  })})`}
-                                </CommandItem>
-                              ))}
+                            {burrowCollateralsQuery.data?.holdings.collateral.map(
+                              (holding) => {
+                                const token = getTokenDetails(holding.token_id);
+                                if (!token) return null;
+
+                                return (
+                                  <CommandItem
+                                    value={`collateral-${token.ftMetadata.accountId}`}
+                                    key={`collateral-${token.ftMetadata.accountId}`}
+                                    onSelect={() => {
+                                      form.setValue(
+                                        "token",
+                                        token.ftMetadata.accountId,
+                                      );
+                                      setSelectedTokenType("collateral");
+                                    }}
+                                  >
+                                    <CheckIcon
+                                      className={cn(
+                                        "mr-2 h-4 w-4",
+                                        token.ftMetadata.accountId ===
+                                          field.value &&
+                                          selectedTokenType === "collateral"
+                                          ? "opacity-100"
+                                          : "opacity-0",
+                                      )}
+                                    />
+                                    {`${
+                                      token.ftMetadata.symbol
+                                    } (Collateral: ${getFormattedAmount({
+                                      balance: holding.balance,
+                                      decimals:
+                                        token.ftMetadata.decimals +
+                                        token.config.config.extra_decimals,
+                                      symbol: token.ftMetadata.symbol,
+                                    })})`}
+                                  </CommandItem>
+                                );
+                              },
+                            )}
                           </CommandGroup>
 
                           <CommandGroup heading="Supplied">
-                            {burrowCollateralsQuery.data?.tokens
-                              .filter(token =>
-                                burrowCollateralsQuery.data?.holdings.supplied
-                                  .some(holding => holding.token_id === token.ftMetadata.accountId)
-                              )
-                              .map((token) => (
-                                <CommandItem
-                                  value={`supplied-${token.ftMetadata.accountId}`}
-                                  key={`supplied-${token.ftMetadata.accountId}`}
-                                  onSelect={() => {
-                                    form.setValue(
-                                      "token",
-                                      token.ftMetadata.accountId,
-                                    );
-                                    setSelectedTokenType('supplied');
-                                  }}
-                                >
-                                  <CheckIcon
-                                    className={cn(
-                                      "mr-2 h-4 w-4",
-                                      token.ftMetadata.accountId === field.value
-                                        ? "opacity-100"
-                                        : "opacity-0",
-                                    )}
-                                  />
-                                  {`${token.ftMetadata.symbol} (Supplied: ${getFormattedAmount({
-                                    balance: burrowCollateralsQuery.data?.holdings.supplied
-                                      .find(holding => holding.token_id === token.ftMetadata.accountId)
-                                      ?.balance || "0",
-                                    decimals:
-                                      token.ftMetadata.decimals +
-                                      token.config.config.extra_decimals,
-                                    symbol: token.ftMetadata.symbol,
-                                  })})`}
-                                </CommandItem>
-                              ))}
+                            {burrowCollateralsQuery.data?.holdings.supplied.map(
+                              (holding) => {
+                                const token = getTokenDetails(holding.token_id);
+                                if (!token) return null;
+
+                                return (
+                                  <CommandItem
+                                    value={`supplied-${token.ftMetadata.accountId}`}
+                                    key={`supplied-${token.ftMetadata.accountId}`}
+                                    onSelect={() => {
+                                      form.setValue(
+                                        "token",
+                                        token.ftMetadata.accountId,
+                                      );
+                                      setSelectedTokenType("supplied");
+                                    }}
+                                  >
+                                    <CheckIcon
+                                      className={cn(
+                                        "mr-2 h-4 w-4",
+                                        token.ftMetadata.accountId ===
+                                          field.value &&
+                                          selectedTokenType === "supplied"
+                                          ? "opacity-100"
+                                          : "opacity-0",
+                                      )}
+                                    />
+                                    {`${
+                                      token.ftMetadata.symbol
+                                    } (Supplied: ${getFormattedAmount({
+                                      balance: holding.balance,
+                                      decimals:
+                                        token.ftMetadata.decimals +
+                                        token.config.config.extra_decimals,
+                                      symbol: token.ftMetadata.symbol,
+                                    })})`}
+                                  </CommandItem>
+                                );
+                              },
+                            )}
                           </CommandGroup>
                         </>
                       )}
@@ -198,31 +233,52 @@ const BurrowWithdraw = () => {
             )}
           />
 
-          {selectedTokenType === 'collateral' && (
+          {selectedTokenType && (
             <TokenWithMaxInput
               control={form.control}
               name="tokenAmount"
-              label={`Amount to withdraw`}
+              label="Amount to withdraw"
               placeholder="10"
               rules={{ required: true }}
               decimals={
-                currentCollateral?.config.config.extra_decimals +
-                currentCollateral?.ftMetadata.decimals || 0
+                currentTokenDetails?.config.config.extra_decimals +
+                  currentTokenDetails?.ftMetadata.decimals || 0
               }
-              maxIndivisible={
-                burrowCollateralsQuery.data?.holdings.collateral
-                  .find(holding => holding.token_id === currentToken)
-                  ?.balance || "0"
-              }
-              symbol={currentCollateral?.ftMetadata.symbol || "loading"}
+              maxIndivisible={currentHolding?.balance || "0"}
+              symbol={selectedSymbol}
             />
+          )}
+
+          {selectedTokenType && currentToken && (
+            <div className="rounded-md border p-4 text-sm">
+              <div className="font-medium">Next action</div>
+              <div className="mt-1 text-muted-foreground">
+                {storageBalanceQuery.isLoading
+                  ? "Checking token storage..."
+                  : needsStorageRegistration
+                  ? `Register wallet to receive ${selectedSymbol}`
+                  : `Create Burrow ${selectedTokenType} withdraw request`}
+              </div>
+              {!storageBalanceQuery.isLoading && (
+                <div className="mt-2 text-xs text-muted-foreground">
+                  Storage:{" "}
+                  {needsStorageRegistration
+                    ? "registration needed"
+                    : "registered"}
+                </div>
+              )}
+            </div>
           )}
 
           <Button
             type="submit"
-            disabled={!selectedTokenType}
+            disabled={!selectedTokenType || withdrawMutation.isLoading}
           >
-            {selectedTokenType === 'supplied' ? 'Withdraw All' : 'Withdraw'}
+            {withdrawMutation.isLoading
+              ? "Creating request..."
+              : needsStorageRegistration
+              ? "Create storage registration request"
+              : "Create withdraw request"}
           </Button>
         </form>
       </Form>

--- a/src/components/defi/RefWithdrawDeposits.tsx
+++ b/src/components/defi/RefWithdrawDeposits.tsx
@@ -1,90 +1,160 @@
 import { toast } from "react-toastify";
 import { Button } from "~/components/ui/button";
-import { useGetRefDeposits, useRefWithdraw } from "~/hooks/defi";
+import {
+  useGetRefDeposits,
+  useGetTokenStorageBalance,
+  useRefWithdraw,
+} from "~/hooks/defi";
 import { useListWallets } from "~/hooks/teams";
 import HeaderTitle from "../ui/header";
 
 export function RefWithdrawDeposits() {
-    const { data: wallets = [] } = useListWallets();
-    const withdrawMutation = useRefWithdraw();
+  const { data: wallets = [] } = useListWallets();
+  const withdrawMutation = useRefWithdraw();
 
-    const handleWithdraw = async (fundingAccId: string, tokenId: string, amount: string) => {
-        try {
-            await withdrawMutation.mutateAsync({
-                fundingAccId,
-                tokenId,
-                amount,
-            });
-            toast.success(`Successfully added request to withdraw ${tokenId}`);
-        } catch (error) {
-            console.error("Error withdrawing:", error);
-            toast.error(`Failed to add withdraw request for ${tokenId}: ${(error as Error).message}`);
-        }
-    };
+  const handleWithdraw = async (
+    fundingAccId: string,
+    tokenId: string,
+    amount: string,
+  ) => {
+    try {
+      const result = await withdrawMutation.mutateAsync({
+        fundingAccId,
+        tokenId,
+        amount,
+      });
+      if (result?.requestType === "storage_deposit") {
+        toast.success(`Storage registration request created for ${tokenId}`);
+        return;
+      }
 
-    if (wallets.length === 0) {
-        return <div>No wallets found</div>;
+      toast.success(`Withdraw request created for ${tokenId}`);
+    } catch (error) {
+      console.error("Error withdrawing:", error);
+      toast.error(
+        `Failed to add withdraw request for ${tokenId}: ${
+          (error as Error).message
+        }`,
+      );
     }
+  };
 
-    return (
-        <div className="mt-8 space-y-8">
-            <hr />
-            <HeaderTitle level="h2">Withdraw pending deposits</HeaderTitle>
-            <p>Withdraw pending (unallocated) deposits from Ref Finance smart contracts. These tokens can be withdrawn to your wallet without any side effects.</p>
+  if (wallets.length === 0) {
+    return <div>No wallets found</div>;
+  }
 
-            {wallets.map((wallet) => (
-                <div key={wallet.id} className="space-y-4">
-                    <HeaderTitle level="h3" text={wallet.walletAddress} />
-                    <WalletDeposits
-                        accountId={wallet.walletAddress}
-                        onWithdraw={(tokenId, amount) => handleWithdraw(wallet.walletAddress, tokenId, amount)}
-                        withdrawingTokenId={withdrawMutation.isLoading ? withdrawMutation.variables?.tokenId : null}
-                    />
-                </div>
-            ))}
+  return (
+    <div className="mt-8 space-y-8">
+      <hr />
+      <HeaderTitle level="h2">Withdraw Rhea internal deposits</HeaderTitle>
+      <p>Pending deposits appear here after liquidity removal is executed.</p>
+
+      {wallets.map((wallet) => (
+        <div key={wallet.id} className="space-y-4">
+          <HeaderTitle level="h3" text={wallet.walletAddress} />
+          <WalletDeposits
+            accountId={wallet.walletAddress}
+            onWithdraw={(tokenId, amount) =>
+              handleWithdraw(wallet.walletAddress, tokenId, amount)
+            }
+            withdrawingTokenId={
+              withdrawMutation.isLoading
+                ? withdrawMutation.variables?.tokenId
+                : null
+            }
+          />
         </div>
-    );
+      ))}
+    </div>
+  );
 }
 
 interface WalletDepositsProps {
-    accountId: string;
-    onWithdraw: (tokenId: string, amount: string) => void;
-    withdrawingTokenId: string | null;
+  accountId: string;
+  onWithdraw: (tokenId: string, amount: string) => void;
+  withdrawingTokenId: string | null;
 }
 
-function WalletDeposits({ accountId, onWithdraw, withdrawingTokenId }: WalletDepositsProps) {
-    const { data, isLoading } = useGetRefDeposits(accountId);
+function WalletDeposits({
+  accountId,
+  onWithdraw,
+  withdrawingTokenId,
+}: WalletDepositsProps) {
+  const { data, isLoading } = useGetRefDeposits(accountId);
 
-    if (isLoading) {
-        return <div>Loading deposits...</div>;
-    }
+  if (isLoading) {
+    return <div>Loading deposits...</div>;
+  }
 
-    if (!data || Object.keys(data).length === 0) {
-        return <div>No deposits found in REF for this wallet</div>;
-    }
+  if (!data || Object.keys(data).length === 0) {
+    return <div>No deposits found in REF for this wallet</div>;
+  }
 
-    return (
-        <div className="space-y-2">
-            {Object.entries(data).map(([tokenId, { amount, formattedAmount, metadata }]) => (
-                <div
-                    key={tokenId}
-                    className="flex items-center justify-between p-4 border rounded-lg"
-                >
-                    <div>
-                        <div className="font-medium">{tokenId}</div>
-                        <div className="text-sm text-gray-500">
-                            {formattedAmount} {metadata?.symbol}
-                        </div>
-                    </div>
-                    <Button
-                        onClick={() => onWithdraw(tokenId, amount)}
-                        variant="outline"
-                        disabled={withdrawingTokenId === tokenId}
-                    >
-                        {withdrawingTokenId === tokenId ? "Withdrawing..." : "Withdraw"}
-                    </Button>
-                </div>
-            ))}
+  return (
+    <div className="space-y-2">
+      {Object.entries(data).map(([tokenId, deposit]) => (
+        <WalletDepositRow
+          key={tokenId}
+          accountId={accountId}
+          tokenId={tokenId}
+          amount={deposit.amount}
+          formattedAmount={deposit.formattedAmount}
+          symbol={deposit.metadata?.symbol}
+          onWithdraw={onWithdraw}
+          isWithdrawing={withdrawingTokenId === tokenId}
+        />
+      ))}
+    </div>
+  );
+}
+
+function WalletDepositRow({
+  accountId,
+  tokenId,
+  amount,
+  formattedAmount,
+  symbol,
+  onWithdraw,
+  isWithdrawing,
+}: {
+  accountId: string;
+  tokenId: string;
+  amount: string;
+  formattedAmount: string;
+  symbol?: string;
+  onWithdraw: (tokenId: string, amount: string) => void;
+  isWithdrawing: boolean;
+}) {
+  const storageBalanceQuery = useGetTokenStorageBalance(tokenId, accountId);
+  const needsStorageRegistration = storageBalanceQuery.data === null;
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border p-4">
+      <div>
+        <div className="font-medium">{tokenId}</div>
+        <div className="text-sm text-gray-500">
+          {formattedAmount} {symbol}
         </div>
-    );
+        <div className="mt-1 text-xs text-gray-500">
+          Storage:{" "}
+          {storageBalanceQuery.isLoading
+            ? "checking..."
+            : needsStorageRegistration
+            ? "registration needed"
+            : "registered"}
+        </div>
+      </div>
+      <Button
+        onClick={() => onWithdraw(tokenId, amount)}
+        variant="outline"
+        disabled={isWithdrawing || storageBalanceQuery.isLoading}
+      >
+        {isWithdrawing
+          ? "Creating request..."
+          : needsStorageRegistration
+          ? "Register wallet"
+          : "Withdraw deposit"}
+      </Button>
+    </div>
+  );
 }

--- a/src/components/defi/RefYourDeposits.tsx
+++ b/src/components/defi/RefYourDeposits.tsx
@@ -7,7 +7,7 @@ import {
   useGetRefPoolShares,
   usePredictRemoveLiquidity,
   useRemoveLiquidity,
-  type LiquidityPoolRef
+  type LiquidityPoolRef,
 } from "~/hooks/defi";
 import { useZodForm } from "~/hooks/form";
 import { useTeamsWalletsWithLockups } from "~/hooks/teams";
@@ -29,12 +29,13 @@ export const RefYourDeposits = () => {
   const form = useZodForm(depositForm);
 
   const poolsQuery = useGetRefLiquidityPoolsForAccount(form.watch("funding"));
+  const watchedPoolId = form.watch("poolId");
   const mySharesQuery = useGetRefPoolShares(
-    form.watch("poolId"),
+    watchedPoolId,
     form.watch("funding"),
   );
   const predictRemoveLiquidityQuery = usePredictRemoveLiquidity({
-    poolId: form.watch("poolId"),
+    poolId: watchedPoolId,
     shares: form.watch("sharesToWithdraw"),
   });
   const walletsQuery = useTeamsWalletsWithLockups();
@@ -43,7 +44,7 @@ export const RefYourDeposits = () => {
   useEffect(() => {
     // reset shares to withdraw to 0 when poolId changes
     form.setValue("sharesToWithdraw", "0");
-  }, [form.watch("poolId")]);
+  }, [form, watchedPoolId]);
 
   const onSubmit = async (values: z.infer<typeof depositForm>) => {
     const endpoint =
@@ -55,7 +56,6 @@ export const RefYourDeposits = () => {
       throw new Error("Pool not found");
     }
 
-
     try {
       await removeLiquidityMut.mutateAsync({
         fundingAccId: values.funding,
@@ -64,7 +64,9 @@ export const RefYourDeposits = () => {
         minAmounts: selectedPool.token_account_ids.map(() => "0"),
       });
 
-      toast.success("Remove liquidity request created");
+      toast.success(
+        "Remove liquidity request created. Execute it before withdrawing internal deposits.",
+      );
     } catch (error) {
       toast.error("Error creating remove liquidity request");
     }
@@ -104,10 +106,7 @@ export const RefYourDeposits = () => {
         {/* Available shares : */}
         {mySharesQuery.data && (
           <div>
-            <p>
-              Shares:{" "}
-              {BigNumber(mySharesQuery.data).toFixed(0)}
-            </p>
+            <p>Shares: {BigNumber(mySharesQuery.data).toFixed(0)}</p>
           </div>
         )}
 
@@ -115,8 +114,7 @@ export const RefYourDeposits = () => {
           name="sharesToWithdraw"
           control={form.control}
           label="Amount of shares to withdraw"
-          maxIndivisible={BigNumber(mySharesQuery.data)
-            .toFixed(0)}
+          maxIndivisible={BigNumber(mySharesQuery.data).toFixed(0)}
           description="Enter the amount of shares you want to withdraw."
           defaultValue="0"
         />
@@ -127,9 +125,7 @@ export const RefYourDeposits = () => {
             <p>
               Remaining shares:{" "}
               {BigNumber(mySharesQuery.data)
-                .minus(
-                  BigNumber(form.watch("sharesToWithdraw")),
-                )
+                .minus(BigNumber(form.watch("sharesToWithdraw")))
                 .toFixed(0)}
             </p>
           </div>
@@ -139,22 +135,38 @@ export const RefYourDeposits = () => {
           <div className="space-y-2">
             <h3 className="font-medium">Predicted tokens to receive:</h3>
             {predictRemoveLiquidityQuery.data.map((amount, index) => {
-              const pool = poolsQuery.data.find(p => p.id === form.watch("poolId"));
+              const pool = poolsQuery.data.find((p) => p.id === watchedPoolId);
               if (!pool) return null;
 
-              const displayAccountId = pool.token_account_ids[index].length > 30
-                ? `${pool.token_account_ids[index].slice(0, 30)}...`
-                : pool.token_account_ids[index];
+              const displayAccountId =
+                pool.token_account_ids[index].length > 30
+                  ? `${pool.token_account_ids[index].slice(0, 30)}...`
+                  : pool.token_account_ids[index];
 
               return (
-                <div key={pool.token_account_ids[index]} className="flex justify-between">
+                <div
+                  key={pool.token_account_ids[index]}
+                  className="flex justify-between"
+                >
                   <span>{`${pool.symbols[index]} (${displayAccountId})`}:</span>
-                  <span>{BigNumber(amount).div(10 ** pool.decimals[index]).toFixed(4)}</span>
+                  <span>
+                    {BigNumber(amount)
+                      .div(10 ** pool.decimals[index])
+                      .toFixed(4)}
+                  </span>
                 </div>
               );
             })}
           </div>
         )}
+
+        <div className="rounded-md border p-4 text-sm">
+          <div className="font-medium">Next action</div>
+          <div className="mt-1 text-muted-foreground">
+            Create remove liquidity request. After approval execution, token
+            deposits will appear below.
+          </div>
+        </div>
 
         <Button type="submit">Create remove liquidity request</Button>
       </form>

--- a/src/hooks/defi.ts
+++ b/src/hooks/defi.ts
@@ -6,6 +6,16 @@ import { parseNearAmount } from "near-api-js/lib/utils/format";
 import { toast } from "react-toastify";
 import { z } from "zod";
 import { fetchJson, getStorageBalance, viewCall } from "~/lib/client";
+import {
+  BURROW_CONTRACT_ID,
+  REF_FINANCE_CONTRACT_ID,
+  buildBurrowWithdrawRequest,
+  buildRefRemoveLiquidityRequest,
+  buildRefWithdrawDepositRequest,
+  type BurrowPositionType,
+  type BurrowWithdrawParams,
+  type RefDeposit,
+} from "~/lib/defi/requests";
 import { type FungibleTokenMetadata } from "~/lib/ft/contract";
 import { type Token } from "~/lib/transformations";
 import {
@@ -67,8 +77,10 @@ export const useGetRefLiquidityPools = (
       ),
     ];
 
-    const ftMetadatas = await getFtMetadataForAccounts(tokenAccountIds, getProvider());
-
+    const ftMetadatas = await getFtMetadataForAccounts(
+      tokenAccountIds,
+      getProvider(),
+    );
 
     return pools
       .filter((pool) => {
@@ -111,7 +123,10 @@ export const useGetPoolsForToken = (tokenId: string) => {
         }),
       ),
     ];
-    const ftMetadatas = await getFtMetadataForAccounts(tokenAccountIds, getProvider());
+    const ftMetadatas = await getFtMetadataForAccounts(
+      tokenAccountIds,
+      getProvider(),
+    );
 
     const accountIdToSymbol: Record<string, string> = {};
     ftMetadatas.forEach((ftMetadata) => {
@@ -222,9 +237,11 @@ export const useDepositToRefLiquidityPool = () => {
         actions: [storageDepositRequest],
       });
 
-      const tokenIds = params.tokenAccIds ||
+      const tokenIds =
+        params.tokenAccIds ||
         [params.tokenLeftAccId, params.tokenRightAccId].filter(Boolean);
-      const amounts = params.tokenAmounts ||
+      const amounts =
+        params.tokenAmounts ||
         [params.tokenLeftAmount, params.tokenRightAmount].filter(Boolean);
 
       for (let i = 0; i < tokenIds.length; i++) {
@@ -446,7 +463,7 @@ export const useGetRefPoolShares = (poolId?: string, accountId?: string) => {
           pool_id: parseInt(poolId),
           account_id: accountId,
         },
-        getProvider()
+        getProvider(),
       );
     },
     { enabled: !!poolId && !!accountId },
@@ -504,31 +521,12 @@ export const withdrawRef = z.object({
 
 export const useWithdrawFromRefLiquidityPool = () => {
   const wsStore = useWalletTerminator();
-  const viewQuery = useGetRefLiquidityPoolsForAccount();
 
   return useMutation({
     mutationFn: async (params: z.infer<typeof withdrawRef>) => {
-      const refAccountId = "v2.ref-finance.near";
-      const storageDepositRequest = transactions.functionCall(
-        "add_request",
-        addMultisigRequestAction(refAccountId, [
-          functionCallAction(
-            "storage_deposit",
-            {
-              account_id: params.fundingAccId,
-              registration_only: false,
-            },
-            parseNearAmount("0.005"),
-            (50 * TGas).toString(),
-          ),
-        ]),
-        new BN(100 * TGas),
-        new BN("0"),
-      );
-
       const removeLiquidityRequest = transactions.functionCall(
         "add_request",
-        addMultisigRequestAction(refAccountId, [
+        addMultisigRequestAction(REF_FINANCE_CONTRACT_ID, [
           functionCallAction(
             "remove_liquidity_by_tokens",
             {
@@ -547,45 +545,8 @@ export const useWithdrawFromRefLiquidityPool = () => {
       await wsStore.signAndSendTransaction({
         senderId: params.fundingAccId,
         receiverId: params.fundingAccId,
-        actions: [storageDepositRequest],
-      });
-      await wsStore.signAndSendTransaction({
-        senderId: params.fundingAccId,
-        receiverId: params.fundingAccId,
         actions: [removeLiquidityRequest],
       });
-
-      await viewQuery.refetch();
-
-      for (let i = 0; i < params.tokens.length; i++) {
-        if (params.amounts[i] === "0") {
-          continue;
-        }
-
-        const withdraw = transactions.functionCall(
-          "add_request",
-          addMultisigRequestAction(refAccountId, [
-            functionCallAction(
-              "withdraw",
-              {
-                token_id: params.tokens[i],
-                amount: "0",
-                unregister: false,
-              },
-              "1",
-              (200 * TGas).toString(),
-            ),
-          ]),
-          new BN(300 * TGas),
-          new BN("0"),
-        );
-
-        await wsStore.signAndSendTransaction({
-          senderId: params.fundingAccId,
-          receiverId: params.fundingAccId,
-          actions: [withdraw],
-        });
-      }
     },
   });
 };
@@ -605,22 +566,9 @@ export const useRemoveLiquidity = () => {
       shares: string;
       minAmounts: string[];
     }) => {
-      const refAccountId = "v2.ref-finance.near";
-
       const removeLiquidityRequest = transactions.functionCall(
         "add_request",
-        addMultisigRequestAction(refAccountId, [
-          functionCallAction(
-            "remove_liquidity",
-            {
-              pool_id: poolId,
-              shares,
-              min_amounts: minAmounts,
-            },
-            "1", // depositYocto
-            (100 * TGas).toString(),
-          ),
-        ]),
+        buildRefRemoveLiquidityRequest({ poolId, shares, minAmounts }),
         new BN(200 * TGas),
         new BN("0"),
       );
@@ -735,7 +683,8 @@ export const useSupplyToBurrow = () => {
 
       const provider = getProvider();
       // Burrow uses wrap.near for native NEAR
-      const burrowTokenId = params.token === "near" ? "wrap.near" : params.token;
+      const burrowTokenId =
+        params.token === "near" ? "wrap.near" : params.token;
 
       const config = await viewCall<BurrowAssetConfig>(
         burrowAccountId,
@@ -772,7 +721,8 @@ export const useSupplyToBurrow = () => {
       );
 
       // For native NEAR, use wrap.near for the transfer
-      const transferTokenId = params.token === "near" ? "wrap.near" : params.token;
+      const transferTokenId =
+        params.token === "near" ? "wrap.near" : params.token;
 
       // If native NEAR is selected, wrap it first before transferring to Burrow
       if (params.token === "near") {
@@ -828,81 +778,58 @@ export const burrowWithdrawFormSchema = z.object({
 export const useWithdrawSupplyFromBurrow = () => {
   const wsStore = useWalletTerminator();
   const { getProvider } = usePersistingStore();
+  const storageDeposit = useStorageDeposit();
 
   return useMutation({
-    mutationFn: async (params: z.infer<typeof burrowWithdrawFormSchema>) => {
-      const burrowAccountId = "contract.main.burrow.near";
-      const oracle = "pyth-oracle.near";
+    mutationFn: async (params: BurrowWithdrawParams) => {
+      const provider = getProvider();
+      const isRegistered = await getStorageBalance(
+        params.token,
+        params.funding,
+        provider,
+      );
+
+      if (isRegistered === null) {
+        toast.warn(
+          "The wallet is not registered to receive this token. A storage registration request was created; execute it before creating the Burrow withdraw request.",
+        );
+        await storageDeposit.mutateAsync({
+          fundingAccId: params.funding,
+          tokenAddress: params.token,
+          receiverAddress: params.funding,
+        });
+        return;
+      }
 
       const config = await viewCall<BurrowAssetConfig>(
-        burrowAccountId,
+        BURROW_CONTRACT_ID,
         "get_asset",
         { token_id: params.token },
-        getProvider()
+        provider,
       );
 
       const ftMetadata = await viewCall<FungibleTokenMetadata>(
         params.token,
         "ft_metadata",
         {},
-        getProvider()
+        provider,
       );
 
       const indivisibleAmount = convertToIndivisibleFormat(
-        params.tokenAmount.toString(),
+        params.amount.toString(),
         ftMetadata.decimals + config.config.extra_decimals,
       );
 
-      const ftTransferCall = config.config.can_use_as_collateral
-        ? transactions.functionCall(
-          "add_request",
-          addMultisigRequestAction(burrowAccountId, [
-            functionCallAction(
-              "execute_with_pyth",
-              {
-                actions: [
-                  {
-                    DecreaseCollateral: {
-                      token_id: params.token,
-                      amount: indivisibleAmount.toString()
-                    }
-                  },
-                  {
-                    Withdraw: {
-                      token_id: params.token
-                    }
-                  }
-                ]
-              },
-              "1",
-              (200 * TGas).toString(),
-            ),
-          ]),
-          new BN(300 * TGas),
-          new BN("0"),
-        )
-        : transactions.functionCall(
-          "add_request",
-          addMultisigRequestAction(burrowAccountId, [
-            functionCallAction(
-              "execute_with_pyth",
-              {
-                actions: [
-                  {
-                    Withdraw: {
-                      token_id: params.token,
-                      max_amount: indivisibleAmount.toString(),
-                    },
-                  },
-                ],
-              },
-              "1",
-              (200 * TGas).toString(),
-            ),
-          ]),
-          new BN(300 * TGas),
-          new BN("0"),
-        );
+      const ftTransferCall = transactions.functionCall(
+        "add_request",
+        buildBurrowWithdrawRequest({
+          tokenId: params.token,
+          positionType: params.positionType,
+          amount: indivisibleAmount.toString(),
+        }),
+        new BN(300 * TGas),
+        new BN("0"),
+      );
 
       await wsStore.signAndSendTransaction({
         senderId: params.funding,
@@ -947,70 +874,77 @@ type BurrowAccountInfo = {
 };
 
 // near contract call-function as-read-only contract.main.burrow.near get_account json-args '{"account_id":"pqla.near"}' network-config mainnet now
-export const useGetBurrowSuppliedTokens = (accountId: string) => {
+export const useGetBurrowSuppliedTokens = (accountId?: string) => {
   const { getProvider } = usePersistingStore();
 
-  return useQuery(["burrowHoldings", accountId], async () => {
-    const burrowAccountId = "contract.main.burrow.near";
-    const holdings = await viewCall<BurrowAccountInfo>(
-      burrowAccountId,
-      "get_account",
-      {
-        account_id: accountId,
-      },
-      getProvider()
-    );
+  return useQuery(
+    ["burrowHoldings", accountId],
+    async () => {
+      if (!accountId) {
+        throw new Error("Account ID is required");
+      }
 
-    let ftMetadatas = await getFtMetadataForAccounts(
-      holdings.collateral.map((t) => t.token_id),
-      getProvider()
-    );
-    let configs = await getBurrowConfigsForTokens(
-      holdings.collateral.map((t) => t.token_id),
-      getProvider()
-    );
-    const ft2 = await getFtMetadataForAccounts(
-      holdings.supplied.map((t) => t.token_id),
-      getProvider()
-    );
-    const c2 = await getBurrowConfigsForTokens(
-      holdings.supplied.map((t) => t.token_id),
-      getProvider()
-    );
-
-    ftMetadatas = ftMetadatas.concat(ft2);
-    configs = configs.concat(c2);
-
-    const suppliedAndCollat = [...holdings.supplied, ...holdings.collateral];
-
-    const tokens = suppliedAndCollat.map((token) => {
-      const b = BigNumber(token.balance);
-      // add some slippage
-      // const c = b.multipliedBy(0.999);
-      token.balance = b.toFixed();
-      const ftMetadata = ftMetadatas.find(
-        (ft) => ft.accountId === token.token_id,
+      const burrowAccountId = "contract.main.burrow.near";
+      const holdings = await viewCall<BurrowAccountInfo>(
+        burrowAccountId,
+        "get_account",
+        {
+          account_id: accountId,
+        },
+        getProvider(),
       );
-      const config = configs.find((c) => c.token_id === token.token_id);
-      console.log(token, ftMetadata, config);
 
-      const r = {
-        token,
-        ftMetadata,
-        config,
+      let ftMetadatas = await getFtMetadataForAccounts(
+        holdings.collateral.map((t) => t.token_id),
+        getProvider(),
+      );
+      let configs = await getBurrowConfigsForTokens(
+        holdings.collateral.map((t) => t.token_id),
+        getProvider(),
+      );
+      const ft2 = await getFtMetadataForAccounts(
+        holdings.supplied.map((t) => t.token_id),
+        getProvider(),
+      );
+      const c2 = await getBurrowConfigsForTokens(
+        holdings.supplied.map((t) => t.token_id),
+        getProvider(),
+      );
+
+      ftMetadatas = ftMetadatas.concat(ft2);
+      configs = configs.concat(c2);
+
+      const suppliedAndCollat = [...holdings.supplied, ...holdings.collateral];
+
+      const tokens = suppliedAndCollat.map((token) => {
+        const b = BigNumber(token.balance);
+        // add some slippage
+        // const c = b.multipliedBy(0.999);
+        token.balance = b.toFixed();
+        const ftMetadata = ftMetadatas.find(
+          (ft) => ft.accountId === token.token_id,
+        );
+        const config = configs.find((c) => c.token_id === token.token_id);
+        console.log(token, ftMetadata, config);
+
+        const r = {
+          token,
+          ftMetadata,
+          config,
+        };
+        console.log(r);
+        return r;
+      });
+
+      return {
+        tokens: tokens,
+        holdings: holdings,
+        ftMetadatas: ftMetadatas,
       };
-      console.log(r);
-      return r;
-    });
-
-    return {
-      tokens: tokens,
-      holdings: holdings,
-      ftMetadatas: ftMetadatas,
-    };
-  });
+    },
+    { enabled: !!accountId },
+  );
 };
-
 
 export const burrowClaimRewardsSchema = z.object({
   accountId: z.string(),
@@ -1068,17 +1002,18 @@ export const useRefSwap = () => {
       const isRegistered = await getStorageBalance(
         params.inAccId,
         params.fundingAccId,
-        getProvider()
+        getProvider(),
       );
       if (isRegistered === null) {
         toast.warn(
-          "Your wallet is not registered with the incoming token. Please add and execute the following transaction first for the swap to work.",
+          "Your wallet is not registered with the incoming token. A storage registration request was created; execute it before creating the swap request.",
         );
         await storageDeposit.mutateAsync({
           fundingAccId: params.fundingAccId,
           tokenAddress: params.inAccId,
           receiverAddress: params.fundingAccId,
         });
+        return;
       }
 
       const ftTransferCallRequest = transactions.functionCall(
@@ -1112,10 +1047,30 @@ type Deposits = {
   [tokenId: string]: string;
 };
 
-export const useGetRefDeposits = (accountId?: string) => {
+export const useGetTokenStorageBalance = (
+  tokenId?: string,
+  accountId?: string,
+) => {
   const { getProvider } = usePersistingStore();
 
   return useQuery(
+    ["tokenStorageBalance", tokenId, accountId],
+    async () => {
+      if (!tokenId || !accountId) return null;
+
+      return getStorageBalance(tokenId, accountId, getProvider());
+    },
+    {
+      enabled: !!tokenId && !!accountId,
+      staleTime: 30 * 1000,
+    },
+  );
+};
+
+export const useGetRefDeposits = (accountId?: string) => {
+  const { getProvider } = usePersistingStore();
+
+  return useQuery<Record<string, RefDeposit> | null>(
     ["refDeposits", accountId],
     async () => {
       if (!accountId) return null;
@@ -1124,40 +1079,45 @@ export const useGetRefDeposits = (accountId?: string) => {
         "v2.ref-finance.near",
         "get_deposits",
         { account_id: accountId },
-        getProvider()
+        getProvider(),
       );
 
       // Filter out zero deposits
-      const nonZeroDeposits = Object.entries(deposits)
-        .filter(([_, amount]) => amount !== "0");
+      const nonZeroDeposits = Object.entries(deposits).filter(
+        ([_, amount]) => amount !== "0",
+      );
 
       if (nonZeroDeposits.length === 0) return {};
 
       const ftMetadatas = await getFtMetadataForAccounts(
         nonZeroDeposits.map(([tokenId]) => tokenId),
-        getProvider()
+        getProvider(),
       );
 
       return Object.fromEntries(
         nonZeroDeposits.map(([tokenId, amount]) => {
-          const metadata = ftMetadatas.find(ft => ft.accountId === tokenId);
+          const metadata = ftMetadatas.find((ft) => ft.accountId === tokenId);
           const formattedAmount = metadata
-            ? (Number(amount) / Math.pow(10, metadata.decimals)).toString()
+            ? new BigNumber(amount)
+                .div(new BigNumber(10).pow(metadata.decimals))
+                .toString()
             : amount;
 
-          return [tokenId, { amount, formattedAmount, metadata }];
-        })
+          return [tokenId, { tokenId, amount, formattedAmount, metadata }];
+        }),
       );
     },
     {
       enabled: !!accountId,
       staleTime: 30 * 1000,
-    }
+    },
   );
 };
 
 export const useRefWithdraw = () => {
   const wsStore = useWalletTerminator();
+  const storageDeposit = useStorageDeposit();
+  const { getProvider } = usePersistingStore();
 
   return useMutation({
     mutationFn: async ({
@@ -1169,24 +1129,29 @@ export const useRefWithdraw = () => {
       tokenId: string;
       amount: string;
     }) => {
-      const refAccountId = "v2.ref-finance.near";
+      const isRegistered = await getStorageBalance(
+        tokenId,
+        fundingAccId,
+        getProvider(),
+      );
+
+      if (isRegistered === null) {
+        toast.warn(
+          "The wallet is not registered to receive this token. A storage registration request was created; execute it before withdrawing the Ref deposit.",
+        );
+        await storageDeposit.mutateAsync({
+          fundingAccId,
+          tokenAddress: tokenId,
+          receiverAddress: fundingAccId,
+        });
+        return { requestType: "storage_deposit" as const };
+      }
 
       const withdrawRequest = transactions.functionCall(
         "add_request",
-        addMultisigRequestAction(refAccountId, [
-          functionCallAction(
-            "withdraw",
-            {
-              token_id: tokenId,
-              amount,
-              unregister: false,
-            },
-            "1",
-            (200 * TGas).toString()
-          ),
-        ]),
+        buildRefWithdrawDepositRequest({ tokenId, amount }),
         new BN(300 * TGas),
-        new BN("0")
+        new BN("0"),
       );
 
       await wsStore.signAndSendTransaction({
@@ -1194,6 +1159,8 @@ export const useRefWithdraw = () => {
         receiverId: fundingAccId,
         actions: [withdrawRequest],
       });
+
+      return { requestType: "withdraw" as const };
     },
   });
 };
@@ -1208,7 +1175,13 @@ export const useRefWithdraw = () => {
 //   "393222484017"
 // ]
 // --------------
-export const usePredictRemoveLiquidity = ({ poolId, shares }: { poolId: string, shares: string }) => {
+export const usePredictRemoveLiquidity = ({
+  poolId,
+  shares,
+}: {
+  poolId: string;
+  shares: string;
+}) => {
   const { getProvider } = usePersistingStore();
 
   return useQuery({
@@ -1218,48 +1191,35 @@ export const usePredictRemoveLiquidity = ({ poolId, shares }: { poolId: string, 
         "v2.ref-finance.near",
         "predict_remove_liquidity",
         { pool_id: parseInt(poolId), shares: shares },
-        getProvider()
+        getProvider(),
       );
 
       return result;
-    }
+    },
+    enabled: !!poolId && !!shares,
   });
-}
+};
 
 export const useWithdrawAllSupplyFromBurrow = () => {
-  const wsStore = useWalletTerminator();
+  const withdrawMutation = useWithdrawSupplyFromBurrow();
 
   return useMutation({
-    mutationFn: async ({ token, funding }: { token: string; funding: string }) => {
-      const burrowAccountId = "contract.main.burrow.near";
-      const oracle = "priceoracle.near";
-
-      const withdrawRequest = transactions.functionCall(
-        "add_request",
-        addMultisigRequestAction(burrowAccountId, [
-          functionCallAction(
-            "execute_with_pyth",
-            {
-              actions: [
-                {
-                  Withdraw: {
-                    token_id: token
-                  }
-                }
-              ]
-            },
-            "1",
-            (200 * TGas).toString()
-          ),
-        ]),
-        new BN(300 * TGas),
-        new BN("0"),
-      );
-
-      await wsStore.signAndSendTransaction({
-        senderId: funding,
-        receiverId: funding,
-        actions: [withdrawRequest],
+    mutationFn: async ({
+      token,
+      funding,
+      amount,
+      positionType = "supplied",
+    }: {
+      token: string;
+      funding: string;
+      amount: string;
+      positionType?: BurrowPositionType;
+    }) => {
+      await withdrawMutation.mutateAsync({
+        token,
+        funding,
+        amount,
+        positionType,
       });
     },
   });

--- a/src/hooks/transfers.ts
+++ b/src/hooks/transfers.ts
@@ -1,9 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
 import BN from "bn.js";
 import { transactions } from "near-api-js";
-import { parseNearAmount } from "near-api-js/lib/utils/format";
 import { toast } from "react-toastify";
 import { getStorageBalance } from "~/lib/client";
+import { buildFtStorageDepositRequest } from "~/lib/defi/requests";
 import { useWalletTerminator } from "~/store/slices/wallet-selector";
 import usePersistingStore from "~/store/useStore";
 import { functionCallAction, transferAction } from "./lockup";
@@ -51,17 +51,10 @@ export const useStorageDeposit = () => {
     }) => {
       const storageDepositRequest = transactions.functionCall(
         "add_request",
-        addMultisigRequestAction(params.tokenAddress, [
-          functionCallAction(
-            "storage_deposit",
-            {
-              account_id: params.receiverAddress,
-              registration_only: false,
-            },
-            parseNearAmount("0.005"),
-            (50 * TGas).toString(),
-          ),
-        ]),
+        buildFtStorageDepositRequest({
+          tokenId: params.tokenAddress,
+          accountId: params.receiverAddress,
+        }),
         new BN(100 * TGas),
         new BN("0"),
       );

--- a/src/lib/defi/requests.ts
+++ b/src/lib/defi/requests.ts
@@ -1,0 +1,176 @@
+import { parseNearAmount } from "near-api-js/lib/utils/format";
+import { type FungibleTokenMetadata } from "~/lib/ft/contract";
+
+export const BURROW_CONTRACT_ID = "contract.main.burrow.near";
+export const REF_FINANCE_CONTRACT_ID = "v2.ref-finance.near";
+
+const T_GAS = 1000000000000;
+const ONE_YOCTO = "1";
+const FT_STORAGE_DEPOSIT = parseNearAmount("0.005") ?? "0";
+
+export type BurrowPositionType = "supplied" | "collateral";
+
+export type BurrowWithdrawParams = {
+  funding: string;
+  token: string;
+  positionType: BurrowPositionType;
+  amount: string;
+};
+
+export type RefDeposit = {
+  tokenId: string;
+  amount: string;
+  formattedAmount: string;
+  metadata?: FungibleTokenMetadata;
+};
+
+type FunctionCallAction = {
+  type: "FunctionCall";
+  method_name: string;
+  args: string;
+  deposit: string;
+  gas: string;
+};
+
+type MultisigRequestPayload = {
+  request: {
+    receiver_id: string;
+    actions: FunctionCallAction[];
+  };
+};
+
+const tGas = (amount: number) => (amount * T_GAS).toString();
+
+const encodeArgs = (args: Record<string, unknown>) => {
+  return btoa(JSON.stringify(args));
+};
+
+const functionCallAction = (
+  methodName: string,
+  args: Record<string, unknown>,
+  deposit: string,
+  gas: string,
+): FunctionCallAction => ({
+  type: "FunctionCall",
+  method_name: methodName,
+  args: encodeArgs(args),
+  deposit,
+  gas,
+});
+
+export const buildBurrowWithdrawRequest = ({
+  tokenId,
+  positionType,
+  amount,
+}: {
+  tokenId: string;
+  positionType: BurrowPositionType;
+  amount: string;
+}): MultisigRequestPayload => {
+  const withdrawAction = {
+    Withdraw: {
+      token_id: tokenId,
+      max_amount: amount,
+    },
+  };
+
+  const actions =
+    positionType === "collateral"
+      ? [
+          {
+            DecreaseCollateral: {
+              token_id: tokenId,
+              max_amount: amount,
+            },
+          },
+          withdrawAction,
+        ]
+      : [withdrawAction];
+
+  return {
+    request: {
+      receiver_id: BURROW_CONTRACT_ID,
+      actions: [
+        functionCallAction(
+          "execute_with_pyth",
+          { actions },
+          ONE_YOCTO,
+          tGas(200),
+        ),
+      ],
+    },
+  };
+};
+
+export const buildRefRemoveLiquidityRequest = ({
+  poolId,
+  shares,
+  minAmounts,
+}: {
+  poolId: number;
+  shares: string;
+  minAmounts: string[];
+}): MultisigRequestPayload => ({
+  request: {
+    receiver_id: REF_FINANCE_CONTRACT_ID,
+    actions: [
+      functionCallAction(
+        "remove_liquidity",
+        {
+          pool_id: poolId,
+          shares,
+          min_amounts: minAmounts,
+        },
+        ONE_YOCTO,
+        tGas(100),
+      ),
+    ],
+  },
+});
+
+export const buildRefWithdrawDepositRequest = ({
+  tokenId,
+  amount,
+}: {
+  tokenId: string;
+  amount: string;
+}): MultisigRequestPayload => ({
+  request: {
+    receiver_id: REF_FINANCE_CONTRACT_ID,
+    actions: [
+      functionCallAction(
+        "withdraw",
+        {
+          token_id: tokenId,
+          amount,
+          unregister: false,
+        },
+        ONE_YOCTO,
+        tGas(200),
+      ),
+    ],
+  },
+});
+
+export const buildFtStorageDepositRequest = ({
+  tokenId,
+  accountId,
+}: {
+  tokenId: string;
+  accountId: string;
+}): MultisigRequestPayload => ({
+  request: {
+    receiver_id: tokenId,
+    actions: [
+      functionCallAction(
+        "storage_deposit",
+        {
+          account_id: accountId,
+          registration_only: false,
+        },
+        FT_STORAGE_DEPOSIT,
+        tGas(50),
+      ),
+    ],
+  },
+});

--- a/src/lib/explain-transaction.ts
+++ b/src/lib/explain-transaction.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/require-await */
+import BigNumber from "bignumber.js";
 import type * as naj from "near-api-js";
 import { formatNearAmount } from "near-api-js/lib/utils/format";
+import {
+  BURROW_CONTRACT_ID,
+  REF_FINANCE_CONTRACT_ID,
+} from "~/lib/defi/requests";
 import {
   initFungibleTokenContract,
   type FungibleTokenContract,
@@ -154,7 +159,7 @@ export async function explainAction(
       }
       // If args are available and methodDescription has a processArgs function, use it
       if (action.args && methodDescription.getExplanation) {
-        const parsedArgs = action.args as unknown as MethodArgs;
+        const parsedArgs = parseFunctionCallArgs(action.args) as MethodArgs;
         const argsDescription = await methodDescription.getExplanation(
           parsedArgs,
           to,
@@ -207,6 +212,34 @@ type FtTransferParams = Parameters<FungibleTokenContract["ft_transfer"]>[0];
 type FtTransferCallParams = Parameters<
   FungibleTokenContract["ft_transfer_call"]
 >[0];
+type ExecuteWithPythParams = {
+  actions: Array<{
+    DecreaseCollateral?: {
+      token_id: string;
+      amount?: string;
+      max_amount?: string;
+    };
+    Withdraw?: {
+      token_id: string;
+      amount?: string;
+      max_amount?: string;
+    };
+  }>;
+};
+type RefRemoveLiquidityParams = {
+  pool_id: number | string;
+  shares: string;
+  min_amounts?: string[];
+};
+type RefWithdrawParams = {
+  token_id?: string;
+  amount?: string;
+  unregister?: boolean;
+};
+type StorageDepositParams = {
+  account_id?: string;
+  registration_only?: boolean;
+};
 
 type MethodArgs =
   | TransferParams
@@ -217,12 +250,76 @@ type MethodArgs =
   | DepositToStakingPoolParams
   | SelectStakingPoolParams
   | FtTransferParams
-  | FtTransferCallParams;
+  | FtTransferCallParams
+  | ExecuteWithPythParams
+  | RefRemoveLiquidityParams
+  | RefWithdrawParams
+  | StorageDepositParams;
 
 type fnCallDetails = {
   desc: string;
   fnReceiverId: string | undefined;
 };
+
+const parseFunctionCallArgs = (args: unknown) => {
+  if (typeof args !== "string") return args;
+
+  try {
+    return JSON.parse(Buffer.from(args, "base64").toString("utf8")) as unknown;
+  } catch {
+    try {
+      return JSON.parse(args) as unknown;
+    } catch {
+      return {};
+    }
+  }
+};
+
+const trimFormattedAmount = (amount: string) => {
+  return amount.replace(/(\.\d*?[1-9])0+$|\.0+$/, "$1");
+};
+
+const formatTokenAmount = async (
+  nearConnection: naj.Account,
+  tokenId: string,
+  amount: string | undefined,
+  decimalsOverride?: number,
+) => {
+  const c = initFungibleTokenContract(nearConnection, tokenId);
+  const metadata = await c.ft_metadata();
+  if (!amount) {
+    return metadata.symbol;
+  }
+
+  const decimals = decimalsOverride ?? metadata.decimals;
+  const formattedAmount = new BigNumber(amount)
+    .div(new BigNumber(10).pow(decimals))
+    .decimalPlaces(6, BigNumber.ROUND_DOWN)
+    .toFormat();
+
+  return `${trimFormattedAmount(formattedAmount)} ${metadata.symbol}`;
+};
+
+const getBurrowAmountDecimals = async (
+  nearConnection: naj.Account,
+  tokenId: string,
+) => {
+  const c = initFungibleTokenContract(nearConnection, tokenId);
+  const metadata = await c.ft_metadata();
+
+  try {
+    const asset = (await nearConnection.viewFunction({
+      contractId: BURROW_CONTRACT_ID,
+      methodName: "get_asset",
+      args: { token_id: tokenId },
+    })) as { config?: { extra_decimals?: number } };
+
+    return metadata.decimals + (asset.config?.extra_decimals ?? 0);
+  } catch {
+    return metadata.decimals;
+  }
+};
+
 const methodDescriptions: {
   [methodName: string]: {
     getExplanation: (
@@ -233,6 +330,128 @@ const methodDescriptions: {
     ) => Promise<fnCallDetails>;
   };
 } = {
+  execute_with_pyth: {
+    getExplanation: async (
+      args: MethodArgs,
+      contract: string,
+      from_account: string,
+      near_connection: naj.Account,
+    ) => {
+      const executeArgs = args as ExecuteWithPythParams;
+      const actions = executeArgs.actions ?? [];
+      const decreaseCollateralAction = actions.find(
+        (action) => action.DecreaseCollateral,
+      )?.DecreaseCollateral;
+      const withdrawAction = actions.find((action) => action.Withdraw)
+        ?.Withdraw;
+
+      if (contract !== BURROW_CONTRACT_ID || !withdrawAction) {
+        return {
+          desc: `Executes a Burrow action.`,
+          fnReceiverId: undefined,
+        };
+      }
+
+      const tokenId =
+        withdrawAction.token_id ?? decreaseCollateralAction?.token_id ?? "";
+      const amount =
+        withdrawAction.max_amount ??
+        withdrawAction.amount ??
+        decreaseCollateralAction?.max_amount ??
+        decreaseCollateralAction?.amount;
+      const decimals = await getBurrowAmountDecimals(near_connection, tokenId);
+      const formattedAmount = await formatTokenAmount(
+        near_connection,
+        tokenId,
+        amount,
+        decimals,
+      );
+
+      return {
+        desc: decreaseCollateralAction
+          ? `Withdraws ${formattedAmount} from Burrow collateral.`
+          : `Withdraws ${formattedAmount} from Burrow supplied balance.`,
+        fnReceiverId: from_account,
+      };
+    },
+  },
+  remove_liquidity: {
+    getExplanation: async (args: MethodArgs) => {
+      const removeLiquidityParams = args as RefRemoveLiquidityParams;
+      return {
+        desc: `Removes liquidity from Rhea pool #${removeLiquidityParams.pool_id}.`,
+        fnReceiverId: REF_FINANCE_CONTRACT_ID,
+      };
+    },
+  },
+  remove_liquidity_by_tokens: {
+    getExplanation: async (args: MethodArgs) => {
+      const removeLiquidityParams = args as RefRemoveLiquidityParams;
+      return {
+        desc: `Removes liquidity from Rhea pool #${removeLiquidityParams.pool_id}.`,
+        fnReceiverId: REF_FINANCE_CONTRACT_ID,
+      };
+    },
+  },
+  withdraw: {
+    getExplanation: async (
+      args: MethodArgs,
+      contract: string,
+      from_account: string,
+      near_connection: naj.Account,
+    ) => {
+      const withdrawParams = args as RefWithdrawParams;
+      if (contract !== REF_FINANCE_CONTRACT_ID || !withdrawParams.token_id) {
+        return {
+          desc: `Withdraws from ${contract}.`,
+          fnReceiverId: from_account,
+        };
+      }
+
+      const formattedAmount = await formatTokenAmount(
+        near_connection,
+        withdrawParams.token_id,
+        withdrawParams.amount,
+      );
+
+      return {
+        desc: `Withdraws ${formattedAmount} from Rhea internal deposits.`,
+        fnReceiverId: from_account,
+      };
+    },
+  },
+  storage_deposit: {
+    getExplanation: async (
+      args: MethodArgs,
+      contract: string,
+      from_account: string,
+      near_connection: naj.Account,
+    ) => {
+      const storageDepositParams = args as StorageDepositParams;
+      const accountId = storageDepositParams.account_id ?? from_account;
+
+      if (contract === REF_FINANCE_CONTRACT_ID) {
+        return {
+          desc: `Registers ${accountId} for Rhea internal deposit storage.`,
+          fnReceiverId: accountId,
+        };
+      }
+
+      try {
+        const c = initFungibleTokenContract(near_connection, contract);
+        const metadata = await c.ft_metadata();
+        return {
+          desc: `Registers ${accountId} to receive ${metadata.symbol}.`,
+          fnReceiverId: accountId,
+        };
+      } catch {
+        return {
+          desc: `Registers ${accountId} for storage on ${contract}.`,
+          fnReceiverId: accountId,
+        };
+      }
+    },
+  },
   // Lockup Contract
   add_full_access_key: {
     getExplanation: async (args: MethodArgs) => {


### PR DESCRIPTION
## Summary
- adds pure DeFi request builders for Burrow, Rhea, and FT storage requests
- changes Burrow withdrawals to use position-based supplied/collateral actions with max_amount
- stages storage registration, Rhea liquidity removal, and internal deposit withdrawals so NearVault creates only the next safe multisig request
- improves pending approval descriptions for Burrow/Rhea/storage actions

## Verification
- SKIP_ENV_VALIDATION=1 npm run lint
- SKIP_ENV_VALIDATION=1 npm run build
- manually decoded FRAX request builder payloads for collateral, supplied, Rhea withdraw, and storage registration

## Staging notes
Please test /defi/withdraw in Vercel staging with a wallet that has Burrow collateral/supplied balances and Rhea internal deposits.